### PR TITLE
Allow users to specify what suffix to add to movie filenames

### DIFF
--- a/EPU_Group_AFIS.py
+++ b/EPU_Group_AFIS.py
@@ -19,8 +19,8 @@ from sklearn.cluster import KMeans, AgglomerativeClustering
 
 def main(xml_dir = os.getcwd(), n_clusters = 1, apix = 1.00,
          mtf_fn = 'MTF.star', voltage = 300.0, cs = 2.7, q0 = 0.1,
-         ftype = 'mrc', movie_dir = '', output_fn = 'movies.star',
-         algorithm = 'kmeans', quiet = False):
+         ftype = 'mrc', movie_dir = '', movie_suffix = 'Fractions',
+         output_fn = 'movies.star', algorithm = 'kmeans', quiet = False):
 
     metadata_fns = []
 
@@ -206,8 +206,8 @@ def main(xml_dir = os.getcwd(), n_clusters = 1, apix = 1.00,
                     break
 
             if movie_fn is None:
-                movie_fn = '{0}_Fractions.{1}'.format(
-                        os.path.join(movie_dir, root), ftype)
+                movie_fn = '{0}_{1}.{2}'.format(
+                        os.path.join(movie_dir, root), movie_suffix, ftype)
 
             f.write('{0}\t{1:d}\n'.format(movie_fn, optics_group))
 
@@ -250,6 +250,9 @@ if __name__ == '__main__':
     parser.add_argument('--movie_dir', '-d', type = str, default = '.',
             help = 'Path to directory with micrograph movies. [.]')
 
+    parser.add_argument('--movie_suffix', type = str, default = 'Fractions',
+            help = 'Suffix to append to micrograph movie filenames. [Fractions]')
+
     parser.add_argument('--output_fn', '-o', type = str,
             default = 'movies.star',
             help = 'Path to output STAR file. [movies.star]')
@@ -267,6 +270,7 @@ if __name__ == '__main__':
          q0 = args.q0,
          ftype = args.ftype,
          movie_dir = args.movie_dir,
+         movie_suffix = args.movie_suffix,
          output_fn = args.output_fn,
          algorithm = args.algorithm,
          quiet = args.quiet)


### PR DESCRIPTION
Hey there, I've noted that with the advent of the Falcon 4 and the EER file format, EPU writes out the files in a slightly different naming convention. 

In particular, instead of ending with *Fractions.tiff or *Fractions.mrc for data collected using a Falcon3 or Gatan camera on the Falcon4 it is now *EER.eer.

I've had a play with your python script during Monash's recent CryoEM workshop (Matt Belousoff ran a session focusing on EER files). We used this script as part of the workflow, which was great, and then ran a "find and replace" command on the output movies.star file to work around the *Fractions.mrc/*EER.eer problem above.

I thought it would be a useful improvement to allow the user to control this parameter if necessary, and keep the current behaviour as the default value.


