### PR TITLE
Update EPU_Group_AFIS.py

### DIFF
--- a/EPU_Group_AFIS.py
+++ b/EPU_Group_AFIS.py
@@ -186,7 +186,7 @@ def main(xml_dir = os.getcwd(), n_clusters = 1, apix = 1.00,
                      optics_group, mtf_fn, apix, voltage, cs, q0))
 
         f.write(' \n\n# version 30001\n\n')
-        f.write('data_movies\n\nloop_\n')
+        f.write('data_micrographs\n\nloop_\n')
         f.write('_rlnMicrographMovieName #1 \n')
         f.write('_rlnOpticsGroup #2 \n')
 


### PR DESCRIPTION
Suggest changing the label "data_movies" to "data_micrographs", I think this is ignored by Relion if I'm reading https://relion.readthedocs.io/en/release-3.1/Reference/Conventions.html correctly. But the label "data_movies" is not picked up by pyem's star parser (https://github.com/asarnow/pyem/blob/master/pyem/star.py). I want to use pyem to import the information in the star file into Cryosparc.